### PR TITLE
Upgrade dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ To verify pact, run below command. Gradle will start Springboot app first, verif
 
 If everything configured properly, you will see the following output in the terminal
 
-	```Verifying a pact between Account_Consumer and accountProvider
+	Verifying a pact between Account_Consumer and accountProvider
          [Using file /Users/tuanpham/works/dius/others/spring-boot-template/pacts/Account_Consumer-Account_Provider.json]
          Create new Accounts
            returns a response which
@@ -41,4 +41,4 @@ If everything configured properly, you will see the following output in the term
                "Content-Type" with value "application/json" (OK)
              has a matching body (OK)
        :account-api:stopProvider
-       :account-api:pactVerify```
+       :account-api:pactVerify

--- a/account-api/build.gradle
+++ b/account-api/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     dependencies {
-        classpath("org.springframework.boot:spring-boot-gradle-plugin:1.4.0.RELEASE")
+        classpath("org.springframework.boot:spring-boot-gradle-plugin:$springbootVersion")
         classpath "com.github.jengelman.gradle.plugins:shadow:1.2.3"
     }
 }
@@ -10,7 +10,7 @@ plugins {
     id "com.wiredforcode.spawn" version "0.8.2"
 }
 
-apply plugin: 'spring-boot'
+apply plugin: "org.springframework.boot"
 apply plugin: "com.wiredforcode.spawn"
 
 jar {

--- a/account-api/build.gradle
+++ b/account-api/build.gradle
@@ -18,12 +18,6 @@ jar {
     version =  "$version"
 }
 
-repositories {
-    jcenter()
-    mavenCentral()
-    maven { url "http://repo.spring.io/libs-snapshot" }
-}
-
 dependencies {
     compile(
         "org.springframework.boot:spring-boot-starter-parent:$springbootVersion",
@@ -38,10 +32,10 @@ dependencies {
         "org.springframework.boot:spring-boot-starter-test:$springbootVersion"
     )
 }
+
 import com.wiredforcode.gradle.spawn.*
 task startProvider(type: SpawnProcessTask, dependsOn: 'assemble') {
-    command "java " +
-            "-Dspring.profiles.active=test -jar ${jar.archivePath}"
+    command "java -Dspring.profiles.active=test -jar ${jar.archivePath}"
     ready 'Started Application'
 }
 

--- a/account-api/build.gradle
+++ b/account-api/build.gradle
@@ -6,7 +6,7 @@ buildscript {
 }
 
 plugins {
-    id "au.com.dius.pact" version "3.3.7"
+    id "au.com.dius.pact" version "3.5.24"
     id "com.wiredforcode.spawn" version "0.8.2"
 }
 

--- a/account-client/build.gradle
+++ b/account-client/build.gradle
@@ -22,7 +22,6 @@ dependencies {
         "au.com.dius:pact-jvm-consumer-junit_2.11:$pactVersion"
     )
 
-
     test {
         systemProperties['pact.rootDir'] = "$projectDir/../pacts"
         println("Generate pact files at $projectDir/../pacts")
@@ -30,6 +29,6 @@ dependencies {
 
     test.doFirst {
         delete "$projectDir/../pacts/"
-        println "Delete existinng pact files at $projectDir/../pacts/"
+        println "Delete existing pact files at $projectDir/../pacts/"
     }
 }

--- a/account-client/build.gradle
+++ b/account-client/build.gradle
@@ -15,11 +15,13 @@ repositories {
 dependencies {
     compile(
         project(":account-api")
-    )
+    ) {
+        exclude group: "org.codehaus.groovy", module: "groovy"
+    }
 
     testCompile (
         "org.assertj:assertj-core:$assertjVersion",
-        "au.com.dius:pact-jvm-consumer-junit_2.11:$pactVersion"
+        "au.com.dius:pact-jvm-consumer-junit_2.12:$pactVersion"
     )
 
     test {

--- a/account-client/build.gradle
+++ b/account-client/build.gradle
@@ -1,23 +1,12 @@
-// Apply the java plugin to add support for Java
-apply plugin: 'java'
-
 jar {
     baseName = 'account-client'
     version =  "$version"
 }
 
-// In this section you declare where to find the dependencies of your project
-repositories {
-    mavenCentral()
-    mavenLocal()
-}
-
 dependencies {
     compile(
         project(":account-api")
-    ) {
-        exclude group: "org.codehaus.groovy", module: "groovy"
-    }
+    )
 
     testCompile (
         "org.assertj:assertj-core:$assertjVersion",

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,3 @@
-apply plugin: 'idea'
-
 allprojects {
     apply plugin: "idea"
     apply plugin: 'java'
@@ -8,9 +6,12 @@ allprojects {
 subprojects {
     buildscript {
         repositories {
-            maven { url "http://repo.spring.io/libs-snapshot" }
             mavenLocal()
             mavenCentral()
         }
+    }
+    repositories {
+        mavenLocal()
+        mavenCentral()
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,4 +4,4 @@ springbootVersion=1.5.19.RELEASE
 
 slf4jVersion=1.7.25
 assertjVersion=3.11.1
-pactVersion=3.3.2
+pactVersion=3.6.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
-version=0.1.0-SNAPSHOT
+version=0.1.1-SNAPSHOT
 
-springbootVersion=1.4.1.RELEASE
+springbootVersion=1.5.19.RELEASE
 
-slf4jVersion=1.7.7
-assertjVersion=3.3.0
+slf4jVersion=1.7.25
+assertjVersion=3.11.1
 pactVersion=3.3.2

--- a/pacts/Account_Consumer-Account_Provider.json
+++ b/pacts/Account_Consumer-Account_Provider.json
@@ -1,72 +1,72 @@
 {
-    "provider": {
-        "name": "Account_Provider"
-    },
-    "consumer": {
-        "name": "Account_Consumer"
-    },
-    "interactions": [
-        {
-            "description": "Create new Accounts",
-            "request": {
-                "method": "POST",
-                "path": "/accounts",
-                "headers": {
-                    "Content-Type": "application/json"
-                },
-                "body": {
-                    "address": "Anywhere",
-                    "id": 99,
-                    "name": "NEW ACCOUNT"
-                }
-            },
-            "response": {
-                "status": 201
-            }
+  "provider": {
+    "name": "Account_Provider"
+  },
+  "consumer": {
+    "name": "Account_Consumer"
+  },
+  "interactions": [
+    {
+      "description": "Create new Accounts",
+      "request": {
+        "method": "POST",
+        "path": "/accounts",
+        "headers": {
+          "Content-Type": "application/json"
         },
-        {
-            "description": "Delete Account",
-            "request": {
-                "method": "DELETE",
-                "path": "/accounts/2"
-            },
-            "response": {
-                "status": 200
-            }
-        },
-        {
-            "description": "Find all Accounts",
-            "request": {
-                "method": "GET",
-                "path": "/accounts"
-            },
-            "response": {
-                "status": 200,
-                "headers": {
-                    "Content-Type": "application/json"
-                }
-            }
-        },
-        {
-            "description": "Get Account By ID",
-            "request": {
-                "method": "GET",
-                "path": "/accounts/1"
-            },
-            "response": {
-                "status": 200,
-                "headers": {
-                    "Content-Type": "application/json"
-                }
-            }
+        "body": {
+          "address": "Anywhere",
+          "name": "NEW ACCOUNT",
+          "id": 99
         }
-    ],
-    "metadata": {
-        "pact-specification": {
-            "version": "2.0.0"
-        },
-        "pact-jvm": {
-            "version": "3.3.2"
+      },
+      "response": {
+        "status": 201
+      }
+    },
+    {
+      "description": "Delete Account",
+      "request": {
+        "method": "DELETE",
+        "path": "/accounts/2"
+      },
+      "response": {
+        "status": 200
+      }
+    },
+    {
+      "description": "Find all Accounts",
+      "request": {
+        "method": "GET",
+        "path": "/accounts"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
         }
+      }
+    },
+    {
+      "description": "Get Account By ID",
+      "request": {
+        "method": "GET",
+        "path": "/accounts/1"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        }
+      }
     }
+  ],
+  "metadata": {
+    "pactSpecification": {
+      "version": "3.0.0"
+    },
+    "pact-jvm": {
+      "version": "3.6.1"
+    }
+  }
 }


### PR DESCRIPTION
# Problem
We use many older versions of dependencies, and as this is a sample project, most people coming to it will expect modern versions.

# Solution
Upgrade dependencies.

# Comments
* I also did a little spring cleaning, removing unnecessary code etc
* I couldn't get Spring Boot 2 to work: when I used it, `account-client` could no longer see the `domain` package from `account-api`. I don't know why - a Gradle configuration issue perhaps?
* I also couldn't get the Pact plugin on 3.6.0+, as it fails with this error:
```
java.lang.NoSuchMethodError: org.codehaus.groovy.runtime.DefaultGroovyMethods.collect(Ljava/lang/Iterable;Lgroovy/lang/Closure;)Ljava/util/List;
```
As far as I can tell this is caused by multiple conflicting Groovy versions on the classpath, but I couldn't figure out how to fix this yet.