### PR TITLE
Gradle tasks for provider-app testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ This is an example of SpringBoot application with basic CRUD, integrating with c
 ## Test API using PACT
 
 Go to the project folder.
+If running on windows - in the following replace
+`./gradlew` by `gradlew.bat`. 
 
 ### Step 1: Generate Pact File
 
@@ -33,8 +35,6 @@ Start the Springboot app first.
 You can verify if the app is running by opening `http://localhost:8080/accounts/`
 
 	./gradlew :account-api:bootRun
-
-
 
 After the app is running - verify pact on the running app.
 

--- a/README.md
+++ b/README.md
@@ -6,15 +6,43 @@ This is an example of SpringBoot application with basic CRUD, integrating with c
 
 ## Test API using PACT
 
+Go to the project folder.
+
 ### Step 1: Generate Pact File
+
 	./gradlew :account-client:test
 
 Gradle task will generate `pacts/Account_Consumer-Account_Provider.json`
 
 ### Step 2: Verify Pact
-To verify pact, run below command. Gradle will start Springboot app first, verify pact, then close the app.
+You can verify the pact by launching the provider explicitly, 
+e.g. during the development process
+or by making gradle launch your provider application. 
 
-	./gradlew pactVerify
+
+#### Step 2a: Let gradle launch the provider-application
+
+To verify pact, run below command. 
+Gradle will start Springboot app first, verify pact, then close the app.
+
+	./gradlew :account-api:pactVerify -PdoLaunchProvider
+
+#### Step 2b: Launch the application explicitely
+
+Start the Springboot app first. 
+You can verify if the app is running by opening `http://localhost:8080/accounts/`
+
+	./gradlew :account-api:bootRun
+
+
+
+After the app is running - verify pact on the running app.
+
+	./gradlew :account-api:pactVerify 
+
+	
+### Step 3: Output
+
 
 If everything configured properly, you will see the following output in the terminal
 

--- a/account-api/build.gradle
+++ b/account-api/build.gradle
@@ -1,53 +1,77 @@
 buildscript {
+    repositories {
+        mavenCentral()
+        maven {
+            url 'https://plugins.gradle.org/m2/'
+        }
+    }
     dependencies {
         classpath("org.springframework.boot:spring-boot-gradle-plugin:$springbootVersion")
-        classpath "com.github.jengelman.gradle.plugins:shadow:1.2.3"
+        classpath "gradle.plugin.com.github.hesch:gradle-execfork-plugin:0.1.15"
     }
 }
 
+
 plugins {
-    id "au.com.dius.pact" version "3.5.24"
-    id "com.wiredforcode.spawn" version "0.8.2"
+    id "au.com.dius.pact" version "4.2.2"
+    id 'com.github.hesch.execfork' version '0.1.15'
 }
 
 apply plugin: "org.springframework.boot"
-apply plugin: "com.wiredforcode.spawn"
 
 jar {
     baseName = 'account-api'
-    version =  "$version"
+    version = "$version"
 }
 
 dependencies {
     compile(
-        "org.springframework.boot:spring-boot-starter-parent:$springbootVersion",
-        "org.springframework.boot:spring-boot-starter-web:$springbootVersion",
-        "org.springframework.boot:spring-boot-starter-jersey:$springbootVersion",
-        "javax.xml.bind:jaxb-api:2.3.1",
-        "org.slf4j:slf4j-api:$slf4jVersion"
+            "org.springframework.boot:spring-boot-starter-parent:$springbootVersion",
+            "org.springframework.boot:spring-boot-starter-web:$springbootVersion",
+            "org.springframework.boot:spring-boot-starter-jersey:$springbootVersion",
+            "javax.xml.bind:jaxb-api:2.3.1",
+            "org.slf4j:slf4j-api:$slf4jVersion"
     )
 
-    testCompile (
-        "org.assertj:assertj-core:$assertjVersion",
-        "org.springframework.boot:spring-boot-starter-test:$springbootVersion"
+    testCompile(
+            "org.assertj:assertj-core:$assertjVersion",
+            "org.springframework.boot:spring-boot-starter-test:$springbootVersion"
     )
 }
 
-import com.wiredforcode.gradle.spawn.*
-task startProvider(type: SpawnProcessTask, dependsOn: 'assemble') {
-    command "java -Dspring.profiles.active=test -jar ${jar.archivePath}"
-    ready 'Started Application'
+task startProvider(type: com.github.psxpaul.task.JavaExecFork) {
+    classpath = sourceSets.main.runtimeClasspath
+    main = 'com.dius.account.Application'
+//    args = [ '-d', '/foo/bar/data', '-v', '-l', '3' ]
+    jvmArgs = ['-Xmx500m', '-Djava.awt.headless=true']
+    workingDir = "$buildDir/server"
+    standardOutput = "$buildDir/daemon.log"
+    errorOutput = "$buildDir/daemon-error.log"
+//    stopAfter = verify
+    waitForPort = 8080
+    waitForOutput = 'started'
+//    environment 'JAVA_HOME', "C:\\Program Files\\AdoptOpenJDK\\jdk-11.0.7.10-hotspot"
 }
 
-task stopProvider(type: KillProcessTask) { }
+
+task startProviderIfNeeded {
+    doLast {
+        println 'Will start the api provider if property "doLaunchProvider" was set via "-PdoLaunchProvider" argument!'
+    }
+}
+// link tasks against each other, if the property "doLaunchProvider" is set
+if (project.hasProperty("doLaunchProvider")) {
+    startProviderIfNeeded.finalizedBy(startProvider)
+}
+
 
 pact {
     serviceProviders {
         accountProvider {
 
             port = 8080
-            startProviderTask = startProvider
-            terminateProviderTask = stopProvider
+            startProviderTask = startProviderIfNeeded
+//            terminateProviderTask = stopProvider
             stateChangeUrl = url('http://localhost:8080/pactStateChange')
 
             hasPactsWith('Account_Consumer') {

--- a/account-client/src/test/java/com/dius/account/infrastructure/client/AccountClientTest.java
+++ b/account-client/src/test/java/com/dius/account/infrastructure/client/AccountClientTest.java
@@ -1,11 +1,11 @@
 package com.dius.account.infrastructure.client;
 
 import au.com.dius.pact.consumer.Pact;
-import au.com.dius.pact.consumer.PactProviderRule;
+import au.com.dius.pact.consumer.PactProviderRuleMk2;
 import au.com.dius.pact.consumer.PactVerification;
 import au.com.dius.pact.consumer.dsl.PactDslJsonBody;
 import au.com.dius.pact.consumer.dsl.PactDslWithProvider;
-import au.com.dius.pact.model.PactFragment;
+import au.com.dius.pact.model.RequestResponsePact;
 import com.dius.account.domain.Account;
 import com.google.common.collect.ImmutableMap;
 import org.junit.Rule;
@@ -31,10 +31,10 @@ public class AccountClientTest {
             .build();
 
     @Rule
-    public PactProviderRule mockProvider = new PactProviderRule("Account_Provider", "localhost", 8080, this);
+    public PactProviderRuleMk2 mockProvider = new PactProviderRuleMk2("Account_Provider", "localhost", 8080, this);
 
     @Pact(consumer = ACCOUNT_CONSUMMER)
-    public PactFragment getFragment(PactDslWithProvider builder) {
+    public RequestResponsePact getFragment(PactDslWithProvider builder) {
 
         return builder
                 .uponReceiving("Get Account By ID")
@@ -44,11 +44,11 @@ public class AccountClientTest {
                 .willRespondWith()
                 .headers(HEADERS)
                 .status(HttpStatus.OK.value())
-                .toFragment();
+                .toPact();
     }
 
     @Pact(consumer = ACCOUNT_CONSUMMER)
-    public PactFragment deleteFragment(PactDslWithProvider builder) {
+    public RequestResponsePact deleteFragment(PactDslWithProvider builder) {
         return builder
                 .uponReceiving("Delete Account")
                 .path("/accounts/2")
@@ -56,11 +56,11 @@ public class AccountClientTest {
 
                 .willRespondWith()
                 .status(HttpStatus.OK.value())
-                .toFragment();
+                .toPact();
     }
 
     @Pact(consumer = ACCOUNT_CONSUMMER)
-    public PactFragment findAllFragment(PactDslWithProvider builder) {
+    public RequestResponsePact findAllFragment(PactDslWithProvider builder) {
 
         return builder
                 .uponReceiving("Find all Accounts")
@@ -70,11 +70,11 @@ public class AccountClientTest {
                 .willRespondWith()
                 .headers(HEADERS)
                 .status(HttpStatus.OK.value())
-                .toFragment();
+                .toPact();
     }
 
     @Pact(consumer = ACCOUNT_CONSUMMER)
-    public PactFragment createFragment(PactDslWithProvider builder) {
+    public RequestResponsePact createFragment(PactDslWithProvider builder) {
 
         return builder
                 .uponReceiving("Create new Accounts")
@@ -85,7 +85,7 @@ public class AccountClientTest {
 
                 .willRespondWith()
                 .status(HttpStatus.CREATED.value())
-                .toFragment();
+                .toPact();
     }
 
     @Test

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Thnx for writing this template!

I updated it since 
the provider-application-side testing 
did not work on windows,
because the spawn plugin does not support windows.

Also I have added a gradle option
to optionally launch the provider-application.
Alternatively one can test it against the running application.

I also have updated the gradle and pact version and changed the deprecated classes.

Please review and merge.